### PR TITLE
Raid scraper fix

### DIFF
--- a/get_raids.py
+++ b/get_raids.py
@@ -8,9 +8,11 @@ os.environ.setdefault(
 django.setup()
 from app.models.gym import Gym
 from app.models.raid_item import RaidItem
+import time, re
 
 params = {
     'by': 'leeds',
+    'excluded': '',
     'pokemon': 'false',
     'pokestops': 'false',
     'gyms': 'true',
@@ -20,9 +22,12 @@ params = {
     'swLng': '-1.5766920',
     'neLat': '53.802341',
     'neLng': '-1.5246490',
-    'alwaysperfect': 'false',
-    'raids': 'false'
+    'alwaysperfect': '1',
+    'raids': 'false',
+    'token': '',
+    'time': int(time.time())
 }
+
 
 proxy_url = os.environ.get('QUOTAGUARDSTATIC_URL')
 
@@ -41,6 +46,10 @@ if time_now.hour in range(6, 21):
             proxies=proxies
         )
     else:
+        page = scraper.get(os.environ.get('POGO_INITIAL_URL'))
+        token_regex = re.compile(r'.*var token = \"([a-z0-9]+)\";')
+        token = token_regex.match(str(page.content)).groups()[0]
+        params['token'] = token
         raids = scraper.get(os.environ.get('POGO_MAP_URL'), params=params)
 
     if raids.status_code == 200:

--- a/get_raids.py
+++ b/get_raids.py
@@ -1,4 +1,4 @@
-import pytz, os, cfscrape
+import pytz, os, cfscrape, time, re
 from datetime import datetime
 import django
 os.environ.setdefault(
@@ -6,9 +6,9 @@ os.environ.setdefault(
     "exclusive_raid_tracker.settings"
 )
 django.setup()
+
 from app.models.gym import Gym
 from app.models.raid_item import RaidItem
-import time, re
 
 params = {
     'by': 'leeds',
@@ -18,10 +18,10 @@ params = {
     'gyms': 'true',
     'scanned': 'false',
     'spawnpoints': 'false',
-    'swLat': '53.791408',
-    'swLng': '-1.5766920',
-    'neLat': '53.802341',
-    'neLng': '-1.5246490',
+    'swLat': '53.64565540685835',
+    'swLng': '-2.061996459960938',
+    'neLat': '53.877226052392416',
+    'neLng': '-0.9084320068359376',
     'alwaysperfect': '1',
     'raids': 'false',
     'token': '',


### PR DESCRIPTION
When submitting a Pull Request upstream it's important to ensure:
- [x] All linting is passing
- [x] All unit tests are passing
- [x] All end-to-end tests are passing
- [x] Any new functionality has 100% coverage (including branches)
- [x] Any new dependencies etc are pinned (i.e. `new_lib==0.0.1`)

In order to scrape raid data now there's a need to get a token from loading the GoMaps webpage. Then a call with this token will return the raid data
